### PR TITLE
feat: add dashboard layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,31 +1,13 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-function App() {
-  const [count, setCount] = useState(0)
+import TopBar from './scenic/TopBar.tsx'
+import KpiTiles from './features/KpiTiles.tsx'
+import LiveFeedPanel from './features/LiveFeedPanel.tsx'
 
+function App() {
   return (
     <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
+      <TopBar />
+      <KpiTiles />
+      <LiveFeedPanel />
     </>
   )
 }

--- a/src/app/state.tsx
+++ b/src/app/state.tsx
@@ -1,0 +1,27 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useState, type ReactNode } from 'react'
+
+type RefreshContextType = {
+  refreshNow: () => void
+  lastRefresh: number
+}
+
+const RefreshContext = createContext<RefreshContextType>({
+  refreshNow: () => {},
+  lastRefresh: Date.now(),
+})
+
+export function RefreshProvider({ children }: { children: ReactNode }) {
+  const [lastRefresh, setLastRefresh] = useState(Date.now())
+  const refreshNow = () => setLastRefresh(Date.now())
+
+  return (
+    <RefreshContext.Provider value={{ refreshNow, lastRefresh }}>
+      {children}
+    </RefreshContext.Provider>
+  )
+}
+
+export function useRefresh() {
+  return useContext(RefreshContext)
+}

--- a/src/features/KpiTiles.tsx
+++ b/src/features/KpiTiles.tsx
@@ -1,0 +1,15 @@
+const tiles = ['Sales', 'COGS', 'Labor', 'Promo', 'Voids']
+
+const KpiTiles = () => {
+  return (
+    <div className="kpi-grid">
+      {tiles.map((name) => (
+        <div key={name} className="kpi-tile">
+          {name}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default KpiTiles

--- a/src/features/LiveFeedPanel.tsx
+++ b/src/features/LiveFeedPanel.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react'
+
+const tabs = ['A15', 'A16', 'A17']
+const chips = ['B15', 'B16', 'B17']
+
+const LiveFeedPanel = () => {
+  const [active, setActive] = useState(0)
+  return (
+    <section className="live-feed-panel">
+      <div className="tabs">
+        {tabs.map((t, idx) => (
+          <button
+            key={t}
+            className={idx === active ? 'active' : ''}
+            onClick={() => setActive(idx)}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      <div className="chips" style={{ display: 'flex', overflowX: 'auto' }}>
+        {chips.map((c) => (
+          <div key={c} className="chip">
+            {c}
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export default LiveFeedPanel

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,9 +6,12 @@ import './styles/kpi.css'
 import './styles/bottom.css'
 import './styles/marquee.css'
 import App from './App.tsx'
+import { RefreshProvider } from './app/state.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <RefreshProvider>
+      <App />
+    </RefreshProvider>
   </StrictMode>,
 )

--- a/src/scenic/ControlPill.tsx
+++ b/src/scenic/ControlPill.tsx
@@ -1,0 +1,12 @@
+import { useRefresh } from '../app/state.tsx'
+
+const ControlPill = () => {
+  const { refreshNow } = useRefresh()
+  return (
+    <button className="control-pill" onClick={refreshNow}>
+      Refresh
+    </button>
+  )
+}
+
+export default ControlPill

--- a/src/scenic/TopBar.tsx
+++ b/src/scenic/TopBar.tsx
@@ -1,0 +1,13 @@
+import logo from '../assets/react.svg'
+import ControlPill from './ControlPill.tsx'
+
+const TopBar = () => {
+  return (
+    <header className="top-bar">
+      <img src={logo} alt="Logo" className="logo" />
+      <ControlPill />
+    </header>
+  )
+}
+
+export default TopBar

--- a/src/styles/kpi.css
+++ b/src/styles/kpi.css
@@ -1,0 +1,13 @@
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: 0.5rem;
+  padding: 1rem;
+}
+
+.kpi-tile {
+  background: #1a1a1a;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  text-align: center;
+}

--- a/src/styles/marquee.css
+++ b/src/styles/marquee.css
@@ -1,0 +1,26 @@
+.live-feed-panel {
+  padding: 1rem;
+}
+
+.live-feed-panel .tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.live-feed-panel .tabs button.active {
+  font-weight: bold;
+}
+
+.live-feed-panel .chips {
+  display: flex;
+  gap: 0.5rem;
+  overflow-x: auto;
+}
+
+.live-feed-panel .chip {
+  padding: 0.25rem 0.5rem;
+  background: #1a1a1a;
+  border-radius: 1rem;
+  white-space: nowrap;
+}

--- a/src/styles/topbar.css
+++ b/src/styles/topbar.css
@@ -1,0 +1,15 @@
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 1rem;
+}
+
+.top-bar .logo {
+  height: 40px;
+}
+
+.control-pill {
+  border-radius: 9999px;
+  padding: 0.25rem 0.75rem;
+}


### PR DESCRIPTION
## Summary
- add RefreshProvider state manager and top bar control pill
- show KPI tiles grid and live feed panel with tabs and chips
- wire up app shell to new scenic and feature components

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c78da3241483209b10409b438dd3fb