### PR TITLE
Add Google Sheets polling data layer and global state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,13 @@
-import { useState } from 'react'
 import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
+import { useAppDispatch, useAppSelector } from './app/state'
+import { selectCount, selectFeed, selectKpis } from './app/selectors'
+
 function App() {
-  const [count, setCount] = useState(0)
+  const dispatch = useAppDispatch()
+  const count = useAppSelector(selectCount)
+  const kpis = useAppSelector(selectKpis)
+  const feed = useAppSelector(selectFeed)
 
   return (
     <>
@@ -16,13 +21,25 @@ function App() {
       </div>
       <h1>Vite + React</h1>
       <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
+        <button onClick={() => dispatch({ type: 'increment' })}>
           count is {count}
         </button>
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>
       </div>
+      <ul>
+        {Object.entries(kpis).map(([key, value]) => (
+          <li key={key}>
+            {key}: {value}
+          </li>
+        ))}
+      </ul>
+      <ul>
+        {feed.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more
       </p>

--- a/src/app/selectors.ts
+++ b/src/app/selectors.ts
@@ -1,0 +1,5 @@
+import { AppState } from './state'
+
+export const selectCount = (state: AppState) => state.count
+export const selectKpis = (state: AppState) => state.kpis
+export const selectFeed = (state: AppState) => state.feed

--- a/src/app/state.tsx
+++ b/src/app/state.tsx
@@ -1,0 +1,76 @@
+/* eslint-disable react-refresh/only-export-components */
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useReducer,
+  type ReactNode,
+} from 'react'
+import { startPolling } from '../data/poller'
+
+export interface AppState {
+  count: number
+  kpis: Record<string, number>
+  feed: string[]
+}
+
+interface IncrementAction {
+  type: 'increment'
+}
+interface SetKpisAction {
+  type: 'set-kpis'
+  kpis: Record<string, number>
+}
+interface AppendFeedAction {
+  type: 'append-feed'
+  feed: string[]
+}
+
+type Action = IncrementAction | SetKpisAction | AppendFeedAction
+
+const initialState: AppState = { count: 0, kpis: {}, feed: [] }
+
+function reducer(state: AppState, action: Action): AppState {
+  switch (action.type) {
+    case 'increment':
+      return { ...state, count: state.count + 1 }
+    case 'set-kpis':
+      return { ...state, kpis: action.kpis }
+    case 'append-feed':
+      return { ...state, feed: [...state.feed, ...action.feed] }
+    default:
+      return state
+  }
+}
+
+const StateContext = createContext<AppState>(initialState)
+const DispatchContext = createContext<React.Dispatch<Action>>(() => undefined)
+
+export function AppStateProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(reducer, initialState)
+
+  useEffect(() => {
+    const stop = startPolling((data) => {
+      dispatch({ type: 'set-kpis', kpis: data.kpis })
+      if (data.feed.length) {
+        dispatch({ type: 'append-feed', feed: data.feed })
+      }
+    })
+    return stop
+  }, [])
+
+  return (
+    <StateContext.Provider value={state}>
+      <DispatchContext.Provider value={dispatch}>{children}</DispatchContext.Provider>
+    </StateContext.Provider>
+  )
+}
+
+export function useAppDispatch() {
+  return useContext(DispatchContext)
+}
+
+export function useAppSelector<T>(selector: (state: AppState) => T): T {
+  const state = useContext(StateContext)
+  return selector(state)
+}

--- a/src/data/adapters.ts
+++ b/src/data/adapters.ts
@@ -1,0 +1,23 @@
+interface ValueRange {
+  range: string
+  values?: string[][]
+}
+
+export function adaptKpis(
+  valueRanges: ValueRange[],
+  entries: [string, string][],
+): Record<string, number> {
+  const result: Record<string, number> = {}
+  entries.forEach(([key], idx) => {
+    const vr = valueRanges[idx]
+    const value = vr?.values?.[0]?.[0]
+    result[key] = Number(value ?? 0)
+  })
+  return result
+}
+
+export function adaptFeed(range: ValueRange): string[] {
+  return (range.values || [])
+    .map((row) => row.join(' ').trim())
+    .filter(Boolean)
+}

--- a/src/data/hardcoded.ts
+++ b/src/data/hardcoded.ts
@@ -1,0 +1,2 @@
+export const GOOGLE_API_KEY = 'YOUR_API_KEY'
+export const GOOGLE_SHEET_ID = 'YOUR_SHEET_ID'

--- a/src/data/poller.ts
+++ b/src/data/poller.ts
@@ -1,0 +1,30 @@
+import { fetchRanges } from './sheetsClient'
+import { KPI_RANGES, LIVE_FEED_RANGE } from './sheetMap'
+import { adaptFeed, adaptKpis } from './adapters'
+
+export function startPolling(
+  callback: (data: { kpis: Record<string, number>; feed: string[] }) => void,
+  interval = 60000,
+) {
+  const entries = Object.entries(KPI_RANGES)
+  const ranges = [...entries.map(([, r]) => r), LIVE_FEED_RANGE]
+  const seen = new Set<string>()
+
+  async function poll() {
+    try {
+      const res = await fetchRanges(ranges)
+      const valueRanges = res.valueRanges || []
+      const kpis = adaptKpis(valueRanges.slice(0, entries.length), entries)
+      const feedAll = adaptFeed(valueRanges[entries.length])
+      const fresh = feedAll.filter((item) => !seen.has(item))
+      fresh.forEach((item) => seen.add(item))
+      callback({ kpis, feed: fresh })
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  poll()
+  const id = setInterval(poll, interval)
+  return () => clearInterval(id)
+}

--- a/src/data/sheetMap.ts
+++ b/src/data/sheetMap.ts
@@ -1,0 +1,6 @@
+export const KPI_RANGES: Record<string, string> = {
+  revenue: 'KPIs!B2',
+  users: 'KPIs!B3'
+}
+
+export const LIVE_FEED_RANGE = 'Feed!A2:B'

--- a/src/data/sheetsClient.ts
+++ b/src/data/sheetsClient.ts
@@ -1,0 +1,12 @@
+import { GOOGLE_API_KEY, GOOGLE_SHEET_ID } from './hardcoded'
+
+export async function fetchRanges(ranges: string[]) {
+  const params = ranges.map((r) => `ranges=${encodeURIComponent(r)}`).join('&')
+  const url =
+    `https://sheets.googleapis.com/v4/spreadsheets/${GOOGLE_SHEET_ID}/values:batchGet?${params}&key=${GOOGLE_API_KEY}`
+  const res = await fetch(url)
+  if (!res.ok) {
+    throw new Error('Failed to fetch ranges')
+  }
+  return res.json()
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,9 +6,12 @@ import './styles/kpi.css'
 import './styles/bottom.css'
 import './styles/marquee.css'
 import App from './App.tsx'
+import { AppStateProvider } from './app/state'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <AppStateProvider>
+      <App />
+    </AppStateProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add data modules for Google Sheets polling and normalization
- introduce global app state with selectors and provider
- route App component through global state instead of local fetches

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c78d986ab4832093e43dab4bdff1c7