### PR TITLE
fix: correct component import paths

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
-import TopBar from './scenic/TopBar.tsx'
+import TopBar from "./scenic/TopBar"
 import KpiTiles from "./features/kpi/KpiTiles"
-import LiveFeedPanel from './features/marquee/LiveFeedPanel.tsx'
+import LiveFeedPanel from "./features/marquee/LiveFeedPanel"
 
 function App() {
   return (


### PR DESCRIPTION
## Summary
- fix App import statements to reference TopBar, KpiTiles, and LiveFeedPanel with extensionless, case-correct paths

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7971f354083209eced3f969c358e9