### PR TITLE
feat: add scenic layers to top bar

### DIFF
--- a/src/scenic/TopBar.tsx
+++ b/src/scenic/TopBar.tsx
@@ -1,10 +1,18 @@
 import logo from '../assets/react.svg'
 import ControlPill from './ControlPill.tsx'
+import Birds, { useBirdProps } from './layers/Birds.tsx'
+import Waves, { useWaveProps } from './layers/Waves.tsx'
 
 const TopBar = () => {
+  const waveProps = useWaveProps()
+  const birdProps = useBirdProps()
   return (
     <header className="top-bar">
-      <img src={logo} alt="Logo" className="logo" />
+      <div className="scenic">
+        <Waves {...waveProps} />
+        <img src={logo} alt="Logo" className="logo" />
+        <Birds {...birdProps} />
+      </div>
       <ControlPill />
     </header>
   )

--- a/src/scenic/layers/Birds.tsx
+++ b/src/scenic/layers/Birds.tsx
@@ -1,0 +1,22 @@
+/* eslint-disable react-refresh/only-export-components */
+import { useRefresh } from '../../app/state.tsx'
+import type { SVGProps } from 'react'
+
+export type BirdsProps = SVGProps<SVGSVGElement>
+
+export const useBirdProps = (): BirdsProps => {
+  const { lastRefresh } = useRefresh()
+  return {
+    className: 'birds',
+    key: lastRefresh,
+  }
+}
+
+const Birds = (props: BirdsProps) => (
+  <svg viewBox="0 0 100 20" {...props}>
+    <path d="M5 10 Q10 0 15 10" stroke="currentColor" fill="none" />
+    <path d="M20 10 Q25 0 30 10" stroke="currentColor" fill="none" />
+  </svg>
+)
+
+export default Birds

--- a/src/scenic/layers/Waves.tsx
+++ b/src/scenic/layers/Waves.tsx
@@ -1,0 +1,22 @@
+/* eslint-disable react-refresh/only-export-components */
+import { useRefresh } from '../../app/state.tsx'
+import type { SVGProps } from 'react'
+
+export type WavesProps = SVGProps<SVGSVGElement>
+
+export const useWaveProps = (): WavesProps => {
+  const { lastRefresh } = useRefresh()
+  return {
+    className: 'waves',
+    key: lastRefresh,
+    preserveAspectRatio: 'none',
+  }
+}
+
+const Waves = (props: WavesProps) => (
+  <svg viewBox="0 0 100 20" {...props}>
+    <path d="M0 20 Q25 0 50 20 T100 20 V20 Z" fill="currentColor" />
+  </svg>
+)
+
+export default Waves

--- a/src/styles/topbar.css
+++ b/src/styles/topbar.css
@@ -1,15 +1,36 @@
 .top-bar {
+  position: relative;
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 0.5rem 1rem;
 }
 
+.top-bar .scenic {
+  position: relative;
+}
+
+.top-bar .waves {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
 .top-bar .logo {
+  position: relative;
+  z-index: 1;
   height: 40px;
 }
 
+.top-bar .birds {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+}
+
 .control-pill {
+  position: relative;
+  z-index: 3;
   border-radius: 9999px;
   padding: 0.25rem 0.75rem;
 }


### PR DESCRIPTION
## Summary
- add Birds and Waves components under new scenic layers
- layer waves behind brand and birds below controls in top bar
- style top bar for proper z-index placement

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Cannot find module './features/kpi/KpiTiles.tsx')*


------
https://chatgpt.com/codex/tasks/task_e_68c798736ce083209078083754dbee85