### PR TITLE
feat: restructure KPI tiles layout

### DIFF
--- a/src/features/kpi/KpiTile.tsx
+++ b/src/features/kpi/KpiTile.tsx
@@ -1,0 +1,23 @@
+import { tileColor } from '../../app/selectors'
+
+interface KpiTileProps {
+  label: string
+  full?: boolean
+}
+
+const KpiTile = ({ label, full }: KpiTileProps) => {
+  return (
+    <div
+      className={`kpi-tile${full ? ' full' : ''}`}
+      style={{
+        backgroundColor: tileColor(),
+        color: '#1a1a1a',
+        fontFamily: 'Manrope, sans-serif',
+      }}
+    >
+      {label}
+    </div>
+  )
+}
+
+export default KpiTile

--- a/src/features/kpi/KpiTiles.tsx
+++ b/src/features/kpi/KpiTiles.tsx
@@ -1,13 +1,18 @@
-const tiles = ['Sales', 'COGS', 'Labor', 'Promo', 'Voids']
+import KpiTile from './KpiTile'
 
 const KpiTiles = () => {
   return (
     <div className="kpi-grid">
-      {tiles.map((name) => (
-        <div key={name} className="kpi-tile">
-          {name}
-        </div>
-      ))}
+      <KpiTile label="Sales" full />
+      <KpiTile label="COGS" />
+      <KpiTile label="Labor" />
+      <KpiTile label="Fixed Cost" />
+      <KpiTile label="A/P" />
+      <KpiTile label="Online Views" />
+      <KpiTile label="Review" />
+      <KpiTile label="Prime" />
+      <KpiTile label="Bank" />
+      <KpiTile label="Net Profit" full />
     </div>
   )
 }

--- a/src/styles/kpi.css
+++ b/src/styles/kpi.css
@@ -1,13 +1,16 @@
 .kpi-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  grid-template-columns: repeat(2, 1fr);
   gap: 0.5rem;
   padding: 1rem;
 }
 
 .kpi-tile {
-  background: #1a1a1a;
   padding: 1rem;
   border-radius: 0.5rem;
   text-align: center;
+}
+
+.kpi-tile.full {
+  grid-column: span 2;
 }


### PR DESCRIPTION
## Summary
- add reusable `KpiTile` component with pastel backgrounds and Manrope text
- lay out KPI dashboard tiles with Sales and Net Profit spanning full width
- streamline KPI grid CSS for two-column layout and remove dark template colors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Waves.tsx requires type-only JSX import)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a3464d8c83208d0d56f251063089