### PR TITLE
feat: show live feed heading and parse rows from state

### DIFF
--- a/src/app/selectors.ts
+++ b/src/app/selectors.ts
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { useRefresh } from './state'
 
 export type Kpis = {
@@ -25,8 +26,28 @@ export function useLoadingError(): unknown {
   return undefined
 }
 
-export function useLiveFeed(): { titles: string[]; rows: string[][] } | undefined {
-  return undefined
+export function useLiveFeed(): { titles: string[]; rows: string[] } | undefined {
+  const { lastRefresh } = useRefresh()
+  const [feed, setFeed] = useState<{ titles: string[]; rows: string[] }>()
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    type FeedState = { titles?: unknown; rows?: unknown }
+    const source: FeedState | undefined = (window as { liveFeed?: FeedState }).liveFeed
+
+    if (source && typeof source === 'object') {
+      const titles = Array.isArray(source.titles)
+        ? (source.titles as string[])
+        : []
+      const rows = Array.isArray(source.rows) ? (source.rows as string[]) : []
+      setFeed({ titles, rows })
+    } else {
+      setFeed(undefined)
+    }
+  }, [lastRefresh])
+
+  return feed
 }
 
 export const useFeed = useLiveFeed

--- a/src/features/marquee/LiveFeedPanel.tsx
+++ b/src/features/marquee/LiveFeedPanel.tsx
@@ -7,7 +7,16 @@ export default function LiveFeedPanel() {
   const lastUpdated = useLastUpdated()
   const feed = useLiveFeed()
   const titles: string[] = useMemo(() => feed?.titles ?? [], [feed])
-  const rows: string[][] = useMemo(() => feed?.rows ?? [], [feed])
+  const rawRows: string[] = useMemo(() => feed?.rows ?? [], [feed])
+  const rows: string[][] = useMemo(
+    () =>
+      rawRows.map((r: string) =>
+        r.split(/-----|—|–/g)
+          .map((s: string) => s.trim())
+          .filter(Boolean),
+      ),
+    [rawRows],
+  )
 
   const [active, setActive] = useState(() => {
     if (typeof window === 'undefined') return 0
@@ -32,7 +41,10 @@ export default function LiveFeedPanel() {
   return (
     <section className="live-feed-panel" aria-labelledby="live-feed-header">
       <header className="live-feed-header" id="live-feed-header">
-        <span className="live-feed-updated">Last Updated {formatted}</span>
+        <div className="live-feed-meta">
+          <h2 className="live-feed-title">GCDC Live Feed</h2>
+          <span className="live-feed-updated">Last Updated {formatted}</span>
+        </div>
         <div className="live-feed-tabs" role="tablist">
           {titles.map((t: string, idx: number) => (
             <button

--- a/src/styles/marquee.css
+++ b/src/styles/marquee.css
@@ -17,6 +17,17 @@
   margin-bottom: 0.75rem;
 }
 
+.live-feed-meta {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.live-feed-title {
+  margin: 0;
+  font-size: 1rem;
+}
+
 .live-feed-updated {
   font-size: 0.875rem;
   color: var(--ink-60, #555);


### PR DESCRIPTION
## Summary
- display "GCDC Live Feed" heading alongside the last updated timestamp
- split live feed rows on various dash separators to populate marquee chips
- implement `useLiveFeed` selector to pull titles and row strings from state

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7a349db2483209763cd24db7ab698